### PR TITLE
Update MatomoSiteConfigExtension.php

### DIFF
--- a/src/Extension/MatomoSiteConfigExtension.php
+++ b/src/Extension/MatomoSiteConfigExtension.php
@@ -43,6 +43,8 @@ class MatomoSiteConfigExtension extends DataExtension {
 
     public function onBeforeWrite()
     {
-        $this->owner->MatomoTrackingURL = $this->getProtocolAgnosticHostname();
+        if($this->owner->MatomoTrackingURL) {
+            $this->owner->MatomoTrackingURL = $this->getProtocolAgnosticHostname();
+        }
     }
 }


### PR DESCRIPTION
When the siteconfig is initially built, there's no check on the MatomoTrackingURL, so it turns an empty string into "///"