### PR TITLE
Ensure that the URL is set

### DIFF
--- a/src/Extension/MatomoSiteConfigExtension.php
+++ b/src/Extension/MatomoSiteConfigExtension.php
@@ -28,15 +28,18 @@ class MatomoSiteConfigExtension extends DataExtension {
 
     private function getProtocolAgnosticHostname()
     {
-        $hostname = rtrim($this->owner->MatomoTrackingURL);
-        $hostname = rtrim($hostname, '/');
-        $hostname .= '/';
+        $hostname = '';
+        if ($this->owner->MatomoTrackingURL) {
+            $hostname = rtrim($this->owner->MatomoTrackingURL);
+            $hostname = rtrim($hostname, '/');
+            $hostname .= '/';
 
-        $hostname = ltrim($hostname);
-        $hostname = str_replace(['http://', 'https://', '//'], '', $hostname);
+            $hostname = ltrim($hostname);
+            $hostname = str_replace(['http://', 'https://', '//'], '', $hostname);
 
-        $hostname = '//' . $hostname;
-
+            $hostname = '//' . $hostname;
+        }
+        
         return $hostname;
 
     }


### PR DESCRIPTION
Without the check, the URL becomes either `///` or an error is thrown due to "rtrim" on an empty string.