### PR TITLE
Simplify getting protocol agnostic hostname

### DIFF
--- a/src/Extension/MatomoSiteConfigExtension.php
+++ b/src/Extension/MatomoSiteConfigExtension.php
@@ -26,26 +26,9 @@ class MatomoSiteConfigExtension extends DataExtension {
         );
     }
 
-    private function getProtocolAgnosticHostname()
-    {
-        $hostname = '';
-        if ($this->owner->MatomoTrackingURL) {
-            $hostname = rtrim($this->owner->MatomoTrackingURL);
-            $hostname = rtrim($hostname, '/');
-            $hostname .= '/';
-
-            $hostname = ltrim($hostname);
-            $hostname = str_replace(['http://', 'https://', '//'], '', $hostname);
-
-            $hostname = '//' . $hostname;
-        }
-        
-        return $hostname;
-
-    }
-
     public function onBeforeWrite()
     {
-        $this->owner->MatomoTrackingURL = $this->getProtocolAgnosticHostname();
+        // only store protocol agnostic hostname if full URL is provided
+        $this->owner->MatomoTrackingURL = parse_url(trim($this->owner->MatomoTrackingURL ?? ''), PHP_URL_HOST));
     }
 }


### PR DESCRIPTION
The private method isn't really needed as it's not used anywhere else in the class and a one liner can be used instead.